### PR TITLE
0909 이동헌 쿼리문 수정(4-1)

### DIFF
--- a/AGENTMASTER_DB/Queries.sql
+++ b/AGENTMASTER_DB/Queries.sql
@@ -146,7 +146,10 @@ SELECT arti.company, summ.article_summary
   FROM "AGENTMASTER"."Article" AS arti
            INNER JOIN "AGENTMASTER"."Article_summary" AS summ
            ON arti.article_id = summ.article_id
- WHERE arti.last_pub = (SELECT last_pub FROM "AGENTMASTER"."Article" ORDER BY last_pub DESC LIMIT 1)
+ WHERE TO_CHAR(arti.last_pub, 'YYYY-MM-DD') = (
+     SELECT MAX(TO_CHAR(last_pub, 'YYYY-MM-DD')) 
+     FROM "AGENTMASTER"."Article"
+ )
  ORDER BY RANDOM()
  LIMIT 5;
 /*


### PR DESCRIPTION
해당 쿼리문에 문제가 발생하여 쿼리문을 수정 했습니다.

문제 쿼리문 - 
/4.1 최신 뉴스 미리보기 정보 랜덤 5개 SELECT/
SELECT arti.company, summ.article_summary
  FROM "AGENTMASTER"."Article" AS arti
           INNER JOIN "AGENTMASTER"."Article_summary" AS summ
           ON arti.article_id = summ.article_id
 WHERE arti.last_pub = (SELECT last_pub FROM "AGENTMASTER"."Article" ORDER BY last_pub DESC LIMIT 1)
 ORDER BY RANDOM()
 LIMIT 5;
/
랜덤한 기사 id의 기사 요약이 5개 출력됩니다.
출력 결과는 신문사 이름, 기사 요약 순서로 출력됩니다.
/

문제 내용 - 출력값이 가장 최신 시점의 최종 게재일에 해당하는 조건으로 설정되어 있습니다. 이는 초 단위까지 조건에 포함되어 있습니다. 해당 시점이 아닌 당일 기사는 제외되는 문제가 발생합니다.

수정된 내용 - 비교 조건을 서브쿼리 출력값의 일자에 해당하는 조건으로 범위를 넓혔습니다. 서브쿼리의 출력값을 ORDER BY 방식에서 집계함수 MAX 방식으로 변경하였습니다.

수정된 쿼리문-
/4.1 최신 뉴스 미리보기 정보 랜덤 5개 SELECT/
SELECT arti.company, summ.article_summary
  FROM "AGENTMASTER"."Article" AS arti
           INNER JOIN "AGENTMASTER"."Article_summary" AS summ
           ON arti.article_id = summ.article_id
 WHERE TO_CHAR(arti.last_pub, 'YYYY-MM-DD') = (
     SELECT MAX(TO_CHAR(last_pub, 'YYYY-MM-DD')) 
     FROM "AGENTMASTER"."Article"
 )
 ORDER BY RANDOM()
 LIMIT 5;
/
랜덤한 기사 id의 기사 요약이 5개 출력됩니다.
출력 결과는 신문사 이름, 기사 요약 순서로 출력됩니다.
/