### PR TITLE
0918 이동헌 쿼리문 수정(8.8)

### DIFF
--- a/AGENTMASTER_DB/Queries.sql
+++ b/AGENTMASTER_DB/Queries.sql
@@ -681,9 +681,14 @@ SELECT sto.stock_name, sin.stock_price, sin.diff_from_prevday, sin.stock_range
   FROM "AGENTMASTER"."Stock" AS sto
            INNER JOIN "AGENTMASTER"."Stock_info" AS sin
            ON sto.stock_id = sin.stock_id
- WHERE field_id = (SELECT field_id FROM "AGENTMASTER"."Stock" WHERE stock_id = 1)
+ WHERE field_id = (SELECT field_id FROM "AGENTMASTER"."Stock" WHERE stock_id = '{stock_id}')
    AND sin.stock_date = (SELECT stock_date FROM "AGENTMASTER"."Stock_info" ORDER BY stock_date DESC LIMIT 1)
- ORDER BY sin.trading_volume DESC;
+ ORDER BY sin.trading_volume DESC
+ LIMIT 4;
+/*
+{stock_id}에 값을 넣어 주세요.
+주식 id에 해당하는 분야 id값 중에서 거래량 기준 상위 4개 종목의 종목명, 주가, 전일비, 등락률 정보를 출력합니다.
+*/
 
 
 /*9 기사 요약문*/


### PR DESCRIPTION
쿼리문 8.8에 수정사항이 발생하여 쿼리문 수정 작업 진행했습니다.

수정 이전 쿼리문:
/8.8 동일 분야 종목 주식 정보 거래량 기준 상위 4개 SELECT/
SELECT sto.stock_name, sin.stock_price, sin.diff_from_prevday, sin.stock_range
  FROM "AGENTMASTER"."Stock" AS sto
           INNER JOIN "AGENTMASTER"."Stock_info" AS sin
           ON sto.stock_id = sin.stock_id
 WHERE field_id = (SELECT field_id FROM "AGENTMASTER"."Stock" WHERE stock_id = 1)
   AND sin.stock_date = (SELECT stock_date FROM "AGENTMASTER"."Stock_info" ORDER BY stock_date DESC LIMIT 1)
 ORDER BY sin.trading_volume DESC;

수정 내용:
stock_id 값에 임시값이 들어간 부분이 존재하여 입력해야하는 입력값 부분을 표시하였습니다.
상위 4개만 출력되도록 수정하였습니다.

수정 이후 쿼리문:
/8.8 동일 분야 종목 주식 정보 거래량 기준 상위 4개 SELECT/
SELECT sto.stock_name, sin.stock_price, sin.diff_from_prevday, sin.stock_range
  FROM "AGENTMASTER"."Stock" AS sto
           INNER JOIN "AGENTMASTER"."Stock_info" AS sin
           ON sto.stock_id = sin.stock_id
 WHERE field_id = (SELECT field_id FROM "AGENTMASTER"."Stock" WHERE stock_id = '{stock_id}')
   AND sin.stock_date = (SELECT stock_date FROM "AGENTMASTER"."Stock_info" ORDER BY stock_date DESC LIMIT 1)
 ORDER BY sin.trading_volume DESC
 LIMIT 4;
 /*
{stock_id}에 값을 넣어 주세요.
주식 id에 해당하는 분야 id값 중에서 거래량 기준 상위 4개 종목의 종목명, 주가, 전일비, 등락률 정보를 출력합니다.
*/